### PR TITLE
Undefine allocators

### DIFF
--- a/ext/attribute_dictionaries.c
+++ b/ext/attribute_dictionaries.c
@@ -36,6 +36,7 @@ static VALUE Sketchup_AttributeDictionaries_length(VALUE self)
 VALUE AttributeDictionaries_Init(VALUE Sketchup, VALUE Sketchup_Entity)
 {
 	VALUE Sketchup_AttributeDictionaries = rb_define_class_under(Sketchup, ATTRIBUTEDICTIONARIES, Sketchup_Entity);
+	rb_undef_alloc_func(Sketchup_AttributeDictionaries);
 	rb_include_module(Sketchup_AttributeDictionaries, rb_mEnumerable);
 	rb_define_method(Sketchup_AttributeDictionaries, "[]", Sketchup_AttributeDictionaries_get, 1);
 	rb_define_method(Sketchup_AttributeDictionaries, "each", Sketchup_AttributeDictionaries_each, 0);

--- a/ext/attribute_dictionary.c
+++ b/ext/attribute_dictionary.c
@@ -140,6 +140,7 @@ static VALUE Sketchup_AttributeDictionary_delete_key(VALUE self, VALUE key)
 VALUE AttributeDictionary_Init(VALUE Sketchup, VALUE Sketchup_Entity)
 {
 	VALUE Sketchup_AttributeDictionary = rb_define_class_under(Sketchup, ATTRIBUTEDICTIONARY, Sketchup_Entity);
+	rb_undef_alloc_func(Sketchup_AttributeDictionary);
 	rb_include_module(Sketchup_AttributeDictionary, rb_mEnumerable);
 	rb_define_method(Sketchup_AttributeDictionary, "[]", Sketchup_AttributeDictionary_get, 1);
 	rb_define_method(Sketchup_AttributeDictionary, "[]=", Sketchup_AttributeDictionary_set, 2);

--- a/ext/behavior.c
+++ b/ext/behavior.c
@@ -6,5 +6,6 @@
 VALUE Behavior_Init(VALUE Sketchup, VALUE Entity)
 {
 	VALUE Sketchup_Behavior = rb_define_class_under(Sketchup, BEHAVIOR, Entity);
+	rb_undef_alloc_func(Sketchup_Behavior);
 	return Sketchup_Behavior;
 }

--- a/ext/component_definition.c
+++ b/ext/component_definition.c
@@ -166,6 +166,7 @@ static VALUE Sketchup_ComponentDefinition_save_as(int argc, VALUE* argv, VALUE s
 VALUE ComponentDefinition_Init(VALUE Sketchup, VALUE Sketchup_DrawingElement)
 {
 	VALUE Sketchup_ComponentDefinition = rb_define_class_under(Sketchup, COMPONENTDEFINITION, Sketchup_DrawingElement);
+	rb_undef_alloc_func(Sketchup_ComponentDefinition);
 	rb_define_method(Sketchup_ComponentDefinition, "name", Sketchup_ComponentDefinition_Get_name, 0);
 	rb_define_method(Sketchup_ComponentDefinition, "name=", Sketchup_ComponentDefinition_Set_name, 1);
 	rb_define_method(Sketchup_ComponentDefinition, "==", Sketchup_ComponentDefinition_Object_equ, 1);

--- a/ext/component_instance.c
+++ b/ext/component_instance.c
@@ -6,5 +6,6 @@
 VALUE ComponentInstance_Init(VALUE Sketchup, VALUE Sketchup_DrawingElement)
 {
 	VALUE Sketchup_ComponentInstance = rb_define_class_under(Sketchup, COMPONENTINSTANCE, Sketchup_DrawingElement);
+	rb_undef_alloc_func(Sketchup_ComponentInstance);
 	return Sketchup_ComponentInstance;
 }

--- a/ext/definition_list.c
+++ b/ext/definition_list.c
@@ -132,6 +132,7 @@ static VALUE Sketchup_DefinitionList_remove(VALUE self, VALUE rb_definition)
 VALUE DefinitionList_Init(VALUE Sketchup, VALUE Sketchup_Entity)
 {
 	VALUE Sketchup_DefinitionList = rb_define_class_under(Sketchup, DEFINITIONLIST, Sketchup_Entity);
+	rb_undef_alloc_func(Sketchup_DefinitionList);
 	rb_include_module(Sketchup_DefinitionList, rb_mEnumerable);
 	rb_define_method(Sketchup_DefinitionList, "each", Sketchup_DefinitionList_each, 0);
 	rb_define_method(Sketchup_DefinitionList, "count", Sketchup_DefinitionList_count, 0);

--- a/ext/drawing_element.c
+++ b/ext/drawing_element.c
@@ -6,5 +6,6 @@
 VALUE DrawingElement_Init(VALUE Sketchup, VALUE Sketchup_Entity)
 {
 	VALUE Sketchup_DrawingElement = rb_define_class_under(Sketchup, DRAWINGELEMENT, Sketchup_Entity);
+	rb_undef_alloc_func(Sketchup_DrawingElement);
 	return Sketchup_DrawingElement;
 }

--- a/ext/entities.c
+++ b/ext/entities.c
@@ -7,5 +7,6 @@
 VALUE Entities_Init(VALUE Sketchup, VALUE rb_cObject)
 {
 	VALUE Sketchup_Entities = rb_define_class_under(Sketchup, ENTITIES, rb_cObject);
+	rb_undef_alloc_func(Sketchup_Entities);
 	return Sketchup_Entities;
 }

--- a/ext/entity.c
+++ b/ext/entity.c
@@ -235,6 +235,7 @@ static VALUE Sketchup_Entity_set_attribute(int argc, VALUE* argv, VALUE self)
 VALUE Entity_Init(VALUE Sketchup, VALUE rb_cObject)
 {
 	VALUE Sketchup_Entity = rb_define_class_under(Sketchup, ENTITY, rb_cObject);
+	rb_undef_alloc_func(Sketchup_Entity);
 	rb_define_method(Sketchup_Entity, "persistent_id", Sketchup_Entity_persistentId, 0);
 	rb_define_method(Sketchup_Entity, "entityID", Sketchup_Entity_entityId, 0);
 	rb_define_method(Sketchup_Entity, "typename", Sketchup_Entity_typename, 0);

--- a/ext/material.c
+++ b/ext/material.c
@@ -222,6 +222,7 @@ static VALUE Sketchup_Material_display_name(VALUE self)
 void Material_Init(VALUE Sketchup, VALUE Sketchup_Entity)
 {
 	VALUE Sketchup_Material = rb_define_class_under(Sketchup, MATERIAL, Sketchup_Entity);
+	rb_undef_alloc_func(Sketchup_Material);
 	rb_define_method(Sketchup_Material, "name", Sketchup_Material_Get_name, 0);
 	rb_define_method(Sketchup_Material, "name=", Sketchup_Material_Set_name, 1);
 	rb_define_method(Sketchup_Material, "texture", Sketchup_Material_Get_texture, 0);

--- a/ext/materials.c
+++ b/ext/materials.c
@@ -73,6 +73,7 @@ static VALUE Sketchup_Materials_get(VALUE self, VALUE key)
 VALUE Materials_Init(VALUE Sketchup, VALUE Sketchup_Entity)
 {
 	VALUE Sketchup_Materials = rb_define_class_under(Sketchup, MATERIALS, Sketchup_Entity);
+	rb_undef_alloc_func(Sketchup_Materials);
 	rb_include_module(Sketchup_Materials, rb_mEnumerable);
 	rb_define_method(Sketchup_Materials, "each", Sketchup_Materials_each, 0);
 	rb_define_method(Sketchup_Materials, "[]", Sketchup_Materials_get, 1);

--- a/ext/model.c
+++ b/ext/model.c
@@ -32,6 +32,7 @@ static VALUE Sketchup_Model_attribute_dictionaries(VALUE self)
 VALUE Model_Init(VALUE Sketchup, VALUE rb_cObject)
 {
 	VALUE Sketchup_Model = rb_define_class_under(Sketchup, MODEL, rb_cObject);
+	rb_undef_alloc_func(Sketchup_Model);
 	rb_define_const(Sketchup_Model, "LOAD_STATUS_SUCCESS", INT2FIX(0));
 	rb_define_const(Sketchup_Model, "LOAD_STATUS_SUCCESS_MORE_RECENT", INT2FIX(1));
 	rb_define_method(Sketchup_Model, "close", Sketchup_Model_close, 0);

--- a/ext/sketchup.c
+++ b/ext/sketchup.c
@@ -73,7 +73,7 @@ void Init_sketchup() {
 	Model_Init(Sketchup, rb_cObject);
 	Color_Init(Sketchup, rb_cObject);
 
-	VALUE Sketchup_Entities = Entities_Init(Sketchup, rb_cObject);
+	Entities_Init(Sketchup, rb_cObject);
 	VALUE Sketchup_Entity = Entity_Init(Sketchup, rb_cObject);
 	Materials_Init(Sketchup, Sketchup_Entity);
 	Material_Init(Sketchup, Sketchup_Entity);

--- a/ext/texture.c
+++ b/ext/texture.c
@@ -6,4 +6,5 @@
 void Texture_Init(VALUE Sketchup, VALUE Sketchup_Entity)
 {
 	VALUE Sketchup_Texture = rb_define_class_under(Sketchup, TEXTURE, Sketchup_Entity);
+	rb_undef_alloc_func(Sketchup_Texture);
 }


### PR DESCRIPTION
Allocators need to be either explicitly defined or undefined.  If this is not done a T_DATA warning is printed the upon first instance creation of affected classes.